### PR TITLE
feat(website): add text search field

### DIFF
--- a/.github/workflows/deploy_github_pages.yml
+++ b/.github/workflows/deploy_github_pages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -60,7 +60,7 @@ type TelegramButtonProps = {
 
 const TelegramButton: FC<TelegramButtonProps> = ({ genre, href }) => {
     return (
-        <a role='button' className='btn btn-neutral btn-sm' href={href}>
+        <a role='button' className='btn btn-sm' href={href}>
             <span className={`iconify ${iconMap[genre]}`} />
             <span className='capitalize'>{genre} Channel</span>
         </a>

--- a/website/src/ConcertFilter.ts
+++ b/website/src/ConcertFilter.ts
@@ -1,0 +1,47 @@
+import { Concert, GenreFilters } from './types.ts';
+import { matchesGenre } from './matchesGenre.ts';
+
+export interface ConcertFilter {
+    filter(concert: Concert): boolean;
+}
+
+export abstract class BaseConcertFilter implements ConcertFilter {
+    abstract filter(concert: Concert): boolean;
+
+    public combine(other: ConcertFilter): ConcertFilter {
+        return {
+            filter: (concert) => this.filter(concert) && other.filter(concert),
+        };
+    }
+}
+
+export class GenreConcertFilter extends BaseConcertFilter {
+    constructor(private readonly genreFilters: GenreFilters) {
+        super();
+    }
+
+    public filter(concert: Concert): boolean {
+        return matchesGenre(concert, this.genreFilters);
+    }
+}
+
+export class TextConcertFilter extends BaseConcertFilter {
+    constructor(private readonly searchString: string) {
+        super();
+    }
+
+    public filter(concert: Concert): boolean {
+        if (this.searchString.length < 1) {
+            return true;
+        }
+
+        const { date, ...propertiesToFilter } = concert;
+
+        return Object.values(propertiesToFilter).some((value) => {
+            if (Array.isArray(value)) {
+                return value.some((it) => it.toLowerCase().includes(this.searchString));
+            }
+            return value.toLowerCase().includes(this.searchString);
+        });
+    }
+}

--- a/website/src/ConcertList.tsx
+++ b/website/src/ConcertList.tsx
@@ -2,6 +2,7 @@ import { FC, useEffect, useMemo, useState } from 'react';
 import { Concert, initialGenreFilters } from './types.ts';
 import { ConcertsForDate } from './ConcertsForDate.tsx';
 import { GenreFilter } from './GenreFilter.tsx';
+import { matchesGenre } from './matchesGenre.ts';
 
 export const ConcertList: FC = () => {
     const [concerts, setConcerts] = useState<Concert[] | Error | undefined>(undefined);
@@ -44,9 +45,11 @@ const ConcertListInner: FC<{ concerts: Concert[] }> = ({ concerts }) => {
     const [filters, setFilters] = useState(initialGenreFilters);
 
     const concertsByDate = useMemo(() => {
+        const filteredConcerts = concerts.filter((concert) => matchesGenre(concert, filters));
+
         const concertsByDate = new Map<string, Concert[]>();
 
-        for (const concert of concerts) {
+        for (const concert of filteredConcerts) {
             const [year, month, day] = concert.date;
             const dateString = new Date(year, month - 1, day).toLocaleDateString('en-us', {
                 weekday: 'long',
@@ -62,20 +65,20 @@ const ConcertListInner: FC<{ concerts: Concert[] }> = ({ concerts }) => {
         }
 
         return concertsByDate;
-    }, [concerts]);
+    }, [concerts, filters]);
 
     return (
         <>
             <div className='flex flex-col items-center'>
                 <p className='font-bold'>Filter by genre:</p>
-                <GenreFilter genre='metal' genreName='Metal' filters={filters} setFilters={setFilters} />
-                <GenreFilter genre='rock' genreName='Rock' filters={filters} setFilters={setFilters} />
-                <GenreFilter genre='punk' genreName='Punk' filters={filters} setFilters={setFilters} />
-                <GenreFilter genre='unknown' genreName='Unknown' filters={filters} setFilters={setFilters} />
+                <GenreFilter genre='metal' filters={filters} setFilters={setFilters} />
+                <GenreFilter genre='rock' filters={filters} setFilters={setFilters} />
+                <GenreFilter genre='punk' filters={filters} setFilters={setFilters} />
+                <GenreFilter genre='unknown' filters={filters} setFilters={setFilters} />
             </div>
             <div>
                 {[...concertsByDate.entries()].map(([date, concerts]) => (
-                    <ConcertsForDate key={date} filters={filters} date={date} concerts={concerts} />
+                    <ConcertsForDate key={date} date={date} concerts={concerts} />
                 ))}
             </div>
         </>

--- a/website/src/ConcertList.tsx
+++ b/website/src/ConcertList.tsx
@@ -1,8 +1,8 @@
-import { FC, useEffect, useMemo, useState } from 'react';
+import { Dispatch, FC, PropsWithChildren, SetStateAction, useEffect, useMemo, useState } from 'react';
 import { Concert, initialGenreFilters } from './types.ts';
 import { ConcertsForDate } from './ConcertsForDate.tsx';
 import { GenreFilter } from './GenreFilter.tsx';
-import { matchesGenre } from './matchesGenre.ts';
+import { ConcertFilter, GenreConcertFilter, TextConcertFilter } from './ConcertFilter.ts';
 
 export const ConcertList: FC = () => {
     const [concerts, setConcerts] = useState<Concert[] | Error | undefined>(undefined);
@@ -42,10 +42,10 @@ export const ConcertList: FC = () => {
 };
 
 const ConcertListInner: FC<{ concerts: Concert[] }> = ({ concerts }) => {
-    const [filters, setFilters] = useState(initialGenreFilters);
+    const [concertsFilter, setConcertsFilter] = useState<ConcertFilter>({ filter: () => true });
 
     const concertsByDate = useMemo(() => {
-        const filteredConcerts = concerts.filter((concert) => matchesGenre(concert, filters));
+        const filteredConcerts = concerts.filter((concert) => concertsFilter.filter(concert));
 
         const concertsByDate = new Map<string, Concert[]>();
 
@@ -65,22 +65,81 @@ const ConcertListInner: FC<{ concerts: Concert[] }> = ({ concerts }) => {
         }
 
         return concertsByDate;
-    }, [concerts, filters]);
+    }, [concerts, concertsFilter]);
 
     return (
         <>
-            <div className='flex flex-col items-center'>
-                <p className='font-bold'>Filter by genre:</p>
-                <GenreFilter genre='metal' filters={filters} setFilters={setFilters} />
-                <GenreFilter genre='rock' filters={filters} setFilters={setFilters} />
-                <GenreFilter genre='punk' filters={filters} setFilters={setFilters} />
-                <GenreFilter genre='unknown' filters={filters} setFilters={setFilters} />
-            </div>
+            <ConcertFilters setConcertsFilter={setConcertsFilter} />
             <div>
                 {[...concertsByDate.entries()].map(([date, concerts]) => (
                     <ConcertsForDate key={date} date={date} concerts={concerts} />
                 ))}
             </div>
         </>
+    );
+};
+
+type ConcertFiltersProps = {
+    setConcertsFilter: Dispatch<SetStateAction<ConcertFilter>>;
+};
+
+const ConcertFilters: FC<ConcertFiltersProps> = ({ setConcertsFilter }: ConcertFiltersProps) => {
+    const [genreFilters, setGenreFilters] = useState(initialGenreFilters);
+    const [textFilter, setTextFilter] = useState('');
+
+    useEffect(() => {
+        setConcertsFilter(
+            new GenreConcertFilter(genreFilters).combine(new TextConcertFilter(textFilter.toLowerCase())),
+        );
+    }, [genreFilters, textFilter]);
+
+    return (
+        <div className='my-2'>
+            <p className='text-center text-xl font-bold text-primary'>Filter concerts</p>
+            <div className='flex flex-wrap justify-center'>
+                <FilterGroupContainer>
+                    <p className='font-bold'>By genre:</p>
+                    <GenreFilter genre='metal' filters={genreFilters} setFilters={setGenreFilters} />
+                    <GenreFilter genre='rock' filters={genreFilters} setFilters={setGenreFilters} />
+                    <GenreFilter genre='punk' filters={genreFilters} setFilters={setGenreFilters} />
+                    <GenreFilter genre='unknown' filters={genreFilters} setFilters={setGenreFilters} />
+                </FilterGroupContainer>
+                <FilterGroupContainer>
+                    <p className='font-bold'>By text:</p>
+                    <label className='input input-bordered my-2 flex items-center gap-2'>
+                        <span className='iconify text-xl mdi--magnify' />
+                        <input
+                            placeholder='Search...'
+                            className='flex-grow'
+                            value={textFilter}
+                            onChange={(e) => setTextFilter(e.target.value)}
+                        />
+                        <ResetButton hidden={textFilter.length == 0} onClick={() => setTextFilter('')} />
+                    </label>
+                </FilterGroupContainer>
+            </div>
+        </div>
+    );
+};
+
+const FilterGroupContainer: FC<PropsWithChildren> = ({ children }) => (
+    <div className='bottom-1 m-1 min-w-60 max-w-80 flex-grow'>{children}</div>
+);
+
+type ResetButtonProps = { hidden: boolean; onClick: () => void };
+
+const ResetButton: FC<ResetButtonProps> = ({ hidden, onClick }) => {
+    return (
+        <button className={`z-10 text-xl ${hidden ? 'hidden' : ''}`} onClick={onClick}>
+            <svg
+                xmlns='http://www.w3.org/2000/svg'
+                className='h-6 w-6'
+                fill='none'
+                viewBox='0 0 24 24'
+                stroke='currentColor'
+            >
+                <path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M6 18L18 6M6 6l12 12' />
+            </svg>
+        </button>
     );
 };

--- a/website/src/ConcertsForDate.tsx
+++ b/website/src/ConcertsForDate.tsx
@@ -1,28 +1,21 @@
-import { Concert, GenreFilters } from './types.ts';
+import { Concert } from './types.ts';
 import ConcertItem from './ConcertItem.tsx';
-import { FC, useMemo } from 'react';
-import { matchesGenre } from './matchesGenre.ts';
+import { FC } from 'react';
 
 type ConcertsForDateProps = {
     date: string;
     concerts: Concert[];
-    filters: GenreFilters;
 };
 
-export const ConcertsForDate: FC<ConcertsForDateProps> = ({ date, concerts, filters }) => {
-    const filteredConcerts = useMemo(
-        () => concerts.filter((concert) => matchesGenre(concert, filters)),
-        [concerts, filters],
-    );
-
-    if (filteredConcerts.length === 0) {
+export const ConcertsForDate: FC<ConcertsForDateProps> = ({ date, concerts }) => {
+    if (concerts.length === 0) {
         return null;
     }
 
     return (
         <div>
             <div className='sticky top-0 z-10 bg-base-100 p-4 font-bold text-primary'>{date}</div>
-            {filteredConcerts.map((concert, index) => (
+            {concerts.map((concert, index) => (
                 <ConcertItem key={index} concert={concert} />
             ))}
         </div>

--- a/website/src/GenreFilter.tsx
+++ b/website/src/GenreFilter.tsx
@@ -3,17 +3,16 @@ import { Dispatch, FC, SetStateAction } from 'react';
 
 type GenreFilterProps = {
     genre: keyof GenreFilters;
-    genreName: string;
     filters: GenreFilters;
     setFilters: Dispatch<SetStateAction<GenreFilters>>;
 };
 
-export const GenreFilter: FC<GenreFilterProps> = ({ genre, genreName, filters, setFilters }) => {
+export const GenreFilter: FC<GenreFilterProps> = ({ genre, filters, setFilters }) => {
     return (
         <label className='label cursor-pointer py-2'>
-            <div className='mx-2 flex items-center'>
+            <div className='mx-2 flex items-center capitalize'>
                 <span className={`iconify ${iconMap[genre]} mr-1`} />
-                {genreName}
+                {genre}
             </div>
             <input
                 className='toggle toggle-primary'

--- a/website/src/GenreFilter.tsx
+++ b/website/src/GenreFilter.tsx
@@ -9,17 +9,17 @@ type GenreFilterProps = {
 
 export const GenreFilter: FC<GenreFilterProps> = ({ genre, filters, setFilters }) => {
     return (
-        <label className='label cursor-pointer py-2'>
-            <div className='mx-2 flex items-center capitalize'>
-                <span className={`iconify ${iconMap[genre]} mr-1`} />
-                {genre}
-            </div>
+        <label className='label ml-2 cursor-pointer justify-start py-2'>
             <input
                 className='toggle toggle-primary'
                 type='checkbox'
                 checked={filters[genre]}
                 onChange={() => setFilters((prevFilters) => ({ ...prevFilters, [genre]: !prevFilters[genre] }))}
             />
+            <div className='mx-2 flex items-center text-right capitalize'>
+                <span className={`iconify ${iconMap[genre]} mr-1`} />
+                {genre}
+            </div>
         </label>
     );
 };


### PR DESCRIPTION
This adds a little text field that filters the concerts by "full text search" (i.e. any of the fields in the JSON except dates contains the string). I find it quite useful because it's very flexible (allows search for locations, genres that we don't offer yet, artists, etc.)

On desktop:
![grafik](https://github.com/user-attachments/assets/292c0f8b-8c82-4192-bc84-50fc5a044d8b)

On mobile:
![grafik](https://github.com/user-attachments/assets/054bb71e-54f8-4406-9eda-3f808f6bc354)
